### PR TITLE
Set jvmTarget for kaptGenerateStubs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ allprojects { p ->
     p.android.lint.checkReleaseBuilds = false
     p.android.namespace = "pkg.android" + p.path.replace(":", ".")
   }
+  tasks.withType(org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask).configureEach {
+    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+  }
 }
 dependencies {
 }


### PR DESCRIPTION
This should fix the build with the changes. In the long run, the project generator should be adjusted to add the corresponding configuration to the right subprojects - or to create convention plugins that can be edited more easily.